### PR TITLE
Fix (de)serialization issue with AggHistogram

### DIFF
--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -275,10 +275,10 @@ class PartitionedHistogram(DaskMethodsMixin):
     """
 
     def __init__(
-        self, dsk: HighLevelGraph, name: str, npartitions: int, histref: bh.Histogram
+        self, dsk: HighLevelGraph, key: str, npartitions: int, histref: bh.Histogram
     ) -> None:
         self.dask: HighLevelGraph = dsk
-        self.key: str = name
+        self.key: str = key
         self.npartitions: int = npartitions
         self._histref: bh.Histogram = histref
 


### PR DESCRIPTION
`__{set,get}state__` needed to be defined accommodating for the difference between `AggHistogram` and `dask.bag.Item`. Fixes https://github.com/dask-contrib/dask-histogram/issues/6