### PR TITLE
Restore some boost-histogram-like functionality

### DIFF
--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -103,7 +103,7 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         return self.dask_name
 
     def __dask_postcompute__(self) -> Any:
-        return first, ()
+        return lambda x: self._in_memory_type(first(x)), ()
 
     def __dask_postpersist__(self) -> Any:
         return self._rebuild, ()
@@ -129,6 +129,16 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         new._dask_name = dask_name
         new._dask = dsk
         return new
+
+    @property
+    def _in_memory_type(self) -> type[bh.Histogram]:
+        if type(self) != Histogram:
+            warnings.warn(
+                """dask_histogram.boost.Histogram has been subclassed without
+                overriding '_in_memory_type', please do so if you would like to
+                receive an instance of subclass rather than a boost_histogram.Histogram!"""
+            )
+        return bh.Histogram
 
     @property
     def dask_name(self) -> str:

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -126,6 +126,7 @@ def test_obj_4D_strcat_rectangular(use_weights):
     if use_weights:
         assert np.allclose(h.variances(), control.variances())
 
+    assert len(h.axes[0]) == 2 and len(control.axes[0]) == 2
     assert all(hx == cx for hx, cx in zip(control.axes[0], h.axes[0]))
 
 

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -94,7 +94,7 @@ def test_obj_3D_rectangular(use_weights):
 
 
 @pytest.mark.parametrize("use_weights", [True, False])
-def test_obj_4D_strcat_rectangular(use_weights):
+def test_obj_5D_strcat_intcat_rectangular(use_weights):
     x = da.random.standard_normal(size=(2000, 3), chunks=(400, 3))
     if use_weights:
         weights = da.random.uniform(0.5, 0.75, size=x.shape[0], chunks=x.chunksize[0])
@@ -105,29 +105,33 @@ def test_obj_4D_strcat_rectangular(use_weights):
 
     h = dhb.Histogram(
         dhb.axis.StrCategory([], growth=True),
+        dhb.axis.IntCategory([], growth=True),
         dhb.axis.Regular(8, -3.5, 3.5),
         dhb.axis.Regular(7, -3.3, 3.3),
         dhb.axis.Regular(9, -3.2, 3.2),
         storage=storage,
     )
-    h.fill("testcat1", *(x.T), weight=weights)
-    h.fill("testcat2", *(x.T), weight=weights)
+    h.fill("testcat1", 1, *(x.T), weight=weights)
+    h.fill("testcat2", 2, *(x.T), weight=weights)
     h = h.compute()
 
     control = bh.Histogram(*h.axes, storage=h.storage_type())
     if use_weights:
-        control.fill("testcat1", *(x.compute().T), weight=weights.compute())
-        control.fill("testcat2", *(x.compute().T), weight=weights.compute())
+        control.fill("testcat1", 1, *(x.compute().T), weight=weights.compute())
+        control.fill("testcat2", 2, *(x.compute().T), weight=weights.compute())
     else:
-        control.fill("testcat1", *(x.compute().T))
-        control.fill("testcat2", *(x.compute().T))
+        control.fill("testcat1", 1, *(x.compute().T))
+        control.fill("testcat2", 2, *(x.compute().T))
 
     assert np.allclose(h.counts(), control.counts())
     if use_weights:
         assert np.allclose(h.variances(), control.variances())
 
     assert len(h.axes[0]) == 2 and len(control.axes[0]) == 2
-    assert all(hx == cx for hx, cx in zip(control.axes[0], h.axes[0]))
+    assert all(cx == hx for cx, hx in zip(control.axes[0], h.axes[0]))
+
+    assert len(h.axes[1]) == 2 and len(control.axes[1]) == 2
+    assert all(cx == hx for cx, hx in zip(control.axes[1], h.axes[1]))
 
 
 def test_histogramdd():

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -93,6 +93,42 @@ def test_obj_3D_rectangular(use_weights):
         assert np.allclose(h.variances(), control.variances())
 
 
+@pytest.mark.parametrize("use_weights", [True, False])
+def test_obj_4D_strcat_rectangular(use_weights):
+    x = da.random.standard_normal(size=(2000, 3), chunks=(400, 3))
+    if use_weights:
+        weights = da.random.uniform(0.5, 0.75, size=x.shape[0], chunks=x.chunksize[0])
+        storage = dhb.storage.Weight()
+    else:
+        weights = None
+        storage = dhb.storage.Double()
+
+    h = dhb.Histogram(
+        dhb.axis.StrCategory([], growth=True),
+        dhb.axis.Regular(8, -3.5, 3.5),
+        dhb.axis.Regular(7, -3.3, 3.3),
+        dhb.axis.Regular(9, -3.2, 3.2),
+        storage=storage,
+    )
+    h.fill("testcat1", *(x.T), weight=weights)
+    h.fill("testcat2", *(x.T), weight=weights)
+    h = h.compute()
+
+    control = bh.Histogram(*h.axes, storage=h.storage_type())
+    if use_weights:
+        control.fill("testcat1", *(x.compute().T), weight=weights.compute())
+        control.fill("testcat2", *(x.compute().T), weight=weights.compute())
+    else:
+        control.fill("testcat1", *(x.compute().T))
+        control.fill("testcat2", *(x.compute().T))
+
+    assert np.allclose(h.counts(), control.counts())
+    if use_weights:
+        assert np.allclose(h.variances(), control.variances())
+
+    assert all(hx == cx for hx, cx in zip(control.axes[0], h.axes[0]))
+
+
 def test_histogramdd():
     x = da.random.standard_normal(size=(3_000,), chunks=500)
     y = da.random.standard_normal(size=(3_000,), chunks=500)


### PR DESCRIPTION
This addresses some issues mentioned at the bottom of #35.
In particular it is now possible to `StrCategory` and `IntCategory` axes, and naturally use growth axes in dask-histogram workflows.

e.g.:
```python3
import dask_histogram as dh
import dask_histogram.boost as dhb

dahist = dhb.Histogram(
    dh.axis.StrCategory([], growth=True),
    dh.axis.Regular(40, 0, 400),
    storage=dh.storage.Weight(),
)

dahist.fill("somecategory", dak.flatten(some_dak_array))
dahist.compute()
```
now functions as one would expect from using boost histogram.

This starts to pave the way for using this as a drop-in backend in the hist package (as requested in https://github.com/scikit-hep/hist/issues/470).