### PR TITLE
Delayed iadd, add, radd for dask_histogram.boost

### DIFF
--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -103,7 +103,7 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
 
     def __radd__(self, other):
         return other.__iadd__(self)
-        
+
     def __dask_graph__(self) -> HighLevelGraph:
         return self._dask
 

--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -88,6 +88,22 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         self._dask_name = None
         self._dask = None
 
+    def __iadd__(self, other):
+        if self.staged_fills() and other.staged_fills():
+            self._staged += other._staged
+        elif not self.staged_fills() and other.staged_fills():
+            self._staged = other._staged
+        if self.staged_fills():
+            self._dask = self._staged.__dask_graph__()
+            self._dask_name = self._staged.name
+        return self
+
+    def __add__(self, other):
+        return self.__iadd__(other)
+
+    def __radd__(self, other):
+        return other.__iadd__(self)
+        
     def __dask_graph__(self) -> HighLevelGraph:
         return self._dask
 


### PR DESCRIPTION
as in title, allows for task graphs where we sum over datasets in a fairly pleasant way:
![image_2023_01_12T02_16_14_165Z](https://user-images.githubusercontent.com/1068089/212205728-7daedd69-812f-42d6-83d0-7203fb7eecac.png)

At some point we should get the other ops but they need a bit more care since they are only well defined on the completely aggregated histogram (so the graph would need a reduction and then apply the op, etc).