### PR TITLE
fix: axes name assignments should persist through .copy() and .compute()

### DIFF
--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -87,10 +87,13 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         self._staged: AggHistogram | None = None
         self._dask_name: str | None = None
         self._dask: HighLevelGraph | None = None
-        self._histref = (
-            axes if isinstance(axes, tuple) else (axes,),
-            storage,
-            metadata,
+
+    @property
+    def _histref(self):
+        return (
+            tuple(self.axes),
+            self.storage_type(),
+            self.metadata,
         )
 
     def __iadd__(self, other):
@@ -248,10 +251,6 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
             pass
         else:
             raise ValueError(f"Cannot interpret input data: {args}")
-
-        # always regenerate the local histref before sending off (so copies, name assignment work)
-        new_histref = (tuple(self.axes), self.storage_type(), self.metadata)
-        self._histref = new_histref
 
         new_fill = factory(*args, histref=self._histref, weights=weight, sample=sample)
         if self._staged is None:

--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -87,9 +87,6 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         self._staged: AggHistogram | None = None
         self._dask_name: str | None = None
         self._dask: HighLevelGraph | None = None
-        print(axes)
-        print(storage)
-        print(metadata)
         self._histref = (
             axes if isinstance(axes, tuple) else (axes,),
             storage,

--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -250,7 +250,7 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
             raise ValueError(f"Cannot interpret input data: {args}")
 
         # always regenerate the local histref before sending off (so copies, name assignment work)
-        new_histref = (tuple(self.axes), self._storage_type(), self.metadata)
+        new_histref = (tuple(self.axes), self.storage_type(), self.metadata)
         self._histref = new_histref
 
         new_fill = factory(*args, histref=self._histref, weights=weight, sample=sample)

--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -250,7 +250,7 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
             raise ValueError(f"Cannot interpret input data: {args}")
 
         # always regenerate the local histref before sending off (so copies, name assignment work)
-        new_histref = (self.axes, self.storage_type(), self.metadata)
+        new_histref = (tuple(self.axes), self._storage_type(), self.metadata)
         self._histref = new_histref
 
         new_fill = factory(*args, histref=self._histref, weights=weight, sample=sample)

--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -87,6 +87,9 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         self._staged: AggHistogram | None = None
         self._dask_name: str | None = None
         self._dask: HighLevelGraph | None = None
+        print(axes)
+        print(storage)
+        print(metadata)
         self._histref = (
             axes if isinstance(axes, tuple) else (axes,),
             storage,
@@ -248,6 +251,10 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
             pass
         else:
             raise ValueError(f"Cannot interpret input data: {args}")
+
+        # always regenerate the local histref before sending off (so copies, name assignment work)
+        new_histref = (self.axes, self.storage_type(), self.metadata)
+        self._histref = new_histref
 
         new_fill = factory(*args, histref=self._histref, weights=weight, sample=sample)
         if self._staged is None:

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -488,7 +488,8 @@ def test_add(use_weights):
 
 def test_name_assignment():
     import dask.array as da
-    import hist
+
+    hist = pytest.importorskip("hist")
     import hist.dask
 
     x = da.random.normal(size=100)

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -507,3 +507,18 @@ def test_name_assignment():
 
     assert h1c.axes.name == ("ax1",)
     assert h2c.axes.name == ("ax2",)
+
+
+def test_histref_pickle():
+    import pickle
+
+    import dask.array as da
+
+    hist = pytest.importorskip("hist")
+    import hist.dask
+
+    x = da.random.normal(size=100)
+    h1 = hist.dask.Hist(hist.axis.Regular(10, -2, 2, name="ax1"))
+    h1.fill(x)  # forces the internal state histref update
+
+    pickle.dumps(h1._histref)

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -484,3 +484,25 @@ def test_add(use_weights):
     if use_weights:
         assert np.allclose(h3.variances(), c3.variances())
         assert np.allclose(h4.variances(), c3.variances())
+
+
+def test_name_assignment():
+    import dask.array as da
+    import hist
+    import hist.dask
+
+    x = da.random.normal(size=100)
+    h1 = hist.dask.Hist(hist.axis.Regular(10, -2, 2, name="ax1"))
+    h2 = h1.copy()
+    h1.fill(x)
+    h2.axes.name = ("ax2",)
+    h2.fill(x)
+
+    assert h1.axes.name == ("ax1",)
+    assert h2.axes.name == ("ax2",)
+
+    h1c = h1.compute()
+    h2c = h2.compute()
+
+    assert h1c.axes.name == ("ax1",)
+    assert h2c.axes.name == ("ax2",)


### PR DESCRIPTION
Fixes #76 