### PR TITLE
fix/feat: Mockable reduction layer

### DIFF
--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -17,6 +17,8 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.threaded import get as tget
 from dask.utils import is_dataframe_like, key_split
 
+from dask_histogram.layers import MockableDataFrameTreeReduction
+
 if TYPE_CHECKING:
     from dask.blockwise import Blockwise
     from numpy.typing import NDArray
@@ -732,8 +734,6 @@ def _reduction(
     ph: PartitionedHistogram,
     split_every: int | None = None,
 ) -> AggHistogram:
-    from dask.layers import DataFrameTreeReduction
-
     if split_every is None:
         split_every = dask.config.get("histogram.aggregation.split_every", 8)
     if split_every is False:
@@ -750,7 +750,7 @@ def _reduction(
         safe_items = [item for item in items if not isinstance(item, tuple)]
         return sum(safe_items)
 
-    dftr = DataFrameTreeReduction(
+    dftr = MockableDataFrameTreeReduction(
         name=name_agg,
         name_input=ph.name,
         npartitions_input=ph.npartitions,

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -750,7 +750,7 @@ def _reduction(
         safe_items = [item for item in items if not isinstance(item, tuple)]
         return sum(safe_items)
 
-    dftr = MockableDataFrameTreeReduction(
+    mdftr = MockableDataFrameTreeReduction(
         name=name_agg,
         name_input=ph.name,
         npartitions_input=ph.npartitions,
@@ -761,7 +761,7 @@ def _reduction(
         tree_node_name=name_comb,
     )
 
-    graph = HighLevelGraph.from_collections(name_agg, dftr, dependencies=(ph,))
+    graph = HighLevelGraph.from_collections(name_agg, mdftr, dependencies=(ph,))
 
     return AggHistogram(graph, name_agg, histref=ph.histref)
 

--- a/src/dask_histogram/layers.py
+++ b/src/dask_histogram/layers.py
@@ -1,0 +1,15 @@
+from dask.layers import DataFrameTreeReduction
+
+
+class MockableDataFrameTreeReduction(DataFrameTreeReduction):
+    def mock(self):
+        return MockableDataFrameTreeReduction(
+            name=self.name,
+            name_input=self.name_input,
+            npartitions_input=1,
+            concat_func=self.concat_func,
+            tree_node_func=self.tree_node_func,
+            finalize_func=self.finalize_func,
+            split_every=self.split_every,
+            tree_node_name=self.tree_node_name,
+        )

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,19 @@
+import dask.array as da
+
+import dask_histogram.boost as dhb
+from dask_histogram.layers import MockableDataFrameTreeReduction
+
+
+def test_mdftr():
+    x = da.random.standard_normal(size=(2000,), chunks=(400,))
+    weights = da.random.uniform(0.5, 0.75, size=x.shape, chunks=x.chunks)
+    storage = dhb.storage.Weight()
+
+    h = dhb.Histogram(dhb.axis.Regular(12, -3, 3), storage=storage)
+    h.fill(x, weight=weights)
+
+    for layer in h.dask:
+        if isinstance(layer, MockableDataFrameTreeReduction):
+            mocked = layer.mock()
+            assert mocked.npartitions_input == 1
+            assert layer.npartitions_input == 5


### PR DESCRIPTION
This lets us plug into dask_awkward's mock idiom so that determining input columns only needs to render the LLG for exactly the first partition.