### PR TITLE
fix: empty dask-boost-histograms will compute to an unfilled histogram

### DIFF
--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -85,8 +85,17 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         """Construct a Histogram object."""
         super().__init__(*axes, storage=storage, metadata=metadata)
         self._staged: AggHistogram | None = None
-        self._dask_name: str | None = None
-        self._dask: HighLevelGraph | None = None
+        self._dask_name: str | None = (
+            f"empty-histogram-{tokenize(*axes, storage, metadata)}"
+        )
+        self._dask: HighLevelGraph | None = HighLevelGraph(
+            {
+                self._dask_name: {
+                    (self._dask_name, 0): (lambda: self._in_memory_type(self),)
+                }
+            },
+            {},
+        )
 
     @property
     def _histref(self):

--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -89,11 +89,7 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
             f"empty-histogram-{tokenize(*axes, storage, metadata)}"
         )
         self._dask: HighLevelGraph | None = HighLevelGraph(
-            {
-                self._dask_name: {
-                    (self._dask_name, 0): (lambda: self._in_memory_type(self),)
-                }
-            },
+            {self._dask_name: {(self._dask_name, 0): (lambda: self,)}},
             {},
         )
 

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -8,6 +8,22 @@ import dask_histogram.boost as dhb
 import dask_histogram.core as dhc
 
 
+def test_empty():
+    h = dhb.Histogram(
+        dhb.axis.StrCategory([], growth=True),
+        dhb.axis.IntCategory([], growth=True),
+        dhb.axis.Regular(8, -3.5, 3.5),
+        dhb.axis.Regular(7, -3.3, 3.3),
+        dhb.axis.Regular(9, -3.2, 3.2),
+        storage=dhb.storage.Weight(),
+    )
+    control = bh.Histogram(*h.axes, storage=h.storage_type())
+    computed = h.compute()
+
+    assert type(computed) is type(control)
+    assert np.allclose(computed.values(), control.values())
+
+
 @pytest.mark.parametrize("use_weights", [True, False])
 def test_obj_1D(use_weights):
     x = da.random.standard_normal(size=(2000,), chunks=(400,))


### PR DESCRIPTION
Fixes #115