### PR TITLE
feat: when adding dask_histgram.boost.Histograms delay creation of task graph and use multi-source tree reduction

### DIFF
--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -236,6 +236,7 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
 
         output_hist = AggHistogram(graph, name_agg, histref=self._histref)
 
+        self._staged = None
         self._staged_result = output_hist
         self._dask = output_hist.dask
         self._dask_name = output_hist.name

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -603,7 +603,7 @@ class AggHistogram(DaskMethodsMixin):
     def __array__(self) -> NDArray[Any]:
         return self.compute().__array__()
 
-    def __iadd__(self, other: Any) -> AggHistogram:        
+    def __iadd__(self, other: Any) -> AggHistogram:
         return _iadd(self, other)
 
     def __add__(self, other: Any) -> AggHistogram:

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -603,9 +603,7 @@ class AggHistogram(DaskMethodsMixin):
     def __array__(self) -> NDArray[Any]:
         return self.compute().__array__()
 
-    def __iadd__(self, other: Any) -> AggHistogram:
-        if isinstance(other, AggHistogram):
-            return _iadd_hist(self, other)
+    def __iadd__(self, other: Any) -> AggHistogram:        
         return _iadd(self, other)
 
     def __add__(self, other: Any) -> AggHistogram:
@@ -1058,91 +1056,6 @@ class BinaryOpAgg:
         return AggHistogram(g, name, histref=ref)
 
 
-class UnorderedTreeReductionBinaryOp:
-    def __init__(
-        self,
-        func: Callable[[Any], Any],
-        name: str | None = None,
-    ) -> None:
-        self.func = func
-        self.__name__ = func.__name__ if name is None else name
-
-    def __call__(self, a: AggHistogram, b: AggHistogram) -> AggHistogram:
-        token = tokenize(a, b)
-        name = f"{self.__name__}-hist-{token}"
-        name_comb = f"{self.__name__}-combine-{token}"
-        deps = []
-        if is_dask_collection(a):
-            deps.append(a)
-        if is_dask_collection(b):
-            deps.append(b)
-
-        layer_a = (
-            [
-                value
-                for value in a.dask.layers.values()
-                if isinstance(value, MockableMultiSourceTreeReduction)
-            ]
-            if is_dask_collection(a)
-            else a
-        )
-        layer_b = (
-            [
-                value
-                for value in b.dask.layers.values()
-                if isinstance(value, MockableMultiSourceTreeReduction)
-            ]
-            if is_dask_collection(b)
-            else b
-        )
-        layer_a = layer_a[0] if len(layer_a) == 1 else None
-        layer_b = layer_b[0] if len(layer_b) == 1 else None
-
-        layer_a_names = layer_a.names_inputs if layer_a else tuple()
-        layer_a_parts = layer_a.npartitions_inputs if layer_a else tuple()
-        layer_b_names = layer_b.names_inputs if layer_b else tuple()
-        layer_b_parts = layer_b.npartitions_inputs if layer_b else tuple()
-
-        a_b_reduction = MockableMultiSourceTreeReduction(
-            name=name,
-            names_inputs=(layer_a_names + layer_b_names),
-            npartitions_inputs=(layer_a_parts + layer_b_parts),
-            concat_func=self.func,
-            tree_node_func=layer_a.tree_node_func,
-            finalize_func=layer_a.finalize_func,
-            split_every=layer_a.split_every,
-            tree_node_name=name_comb,
-        )
-        layers = {name: a_b_reduction}
-        name_dep = set(a_b_reduction.names_inputs)
-        deps = {name: name_dep}
-        layers_a = a.dask.layers.copy()
-        if layer_a:
-            layers_a.pop(a.name)
-        layers_b = b.dask.layers.copy()
-        if layer_b:
-            layers_b.pop(b.name)
-        layers.update(layers_a)
-        layers.update(layers_b)
-
-        a_deps = a.dask.dependencies.copy()
-        a_deps.pop(a.name)
-        b_deps = b.dask.dependencies.copy()
-        b_deps.pop(b.name)
-
-        deps.update(a_deps)
-        deps.update(b_deps)
-
-        g = HighLevelGraph(layers, deps)
-        try:
-            ref = a.histref
-        except AttributeError:
-            ref = b.histref
-
-        return AggHistogram(g, name, histref=ref)
-
-
-_iadd_hist = UnorderedTreeReductionBinaryOp(hist_safe_sum, "add")
 _iadd = BinaryOpAgg(operator.iadd, name="add")
 _isub = BinaryOpAgg(operator.isub, name="sub")
 _imul = BinaryOpAgg(operator.imul, name="mul")

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -17,7 +17,7 @@ from dask.highlevelgraph import HighLevelGraph
 from dask.threaded import get as tget
 from dask.utils import is_dataframe_like, key_split
 
-from dask_histogram.layers import MockableDataFrameTreeReduction
+from dask_histogram.layers import MockableMultiSourceTreeReduction
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -767,10 +767,10 @@ def _reduction(
         safe_items = [item for item in items if not isinstance(item, tuple)]
         return sum(safe_items)
 
-    mdftr = MockableDataFrameTreeReduction(
+    mmstr = MockableMultiSourceTreeReduction(
         name=name_agg,
-        name_input=ph.name,
-        npartitions_input=ph.npartitions,
+        names_inputs=(ph.name,),
+        npartitions_inputs=(ph.npartitions,),
         concat_func=hist_safe_sum,
         tree_node_func=lambda x: x,
         finalize_func=lambda x: x,
@@ -778,7 +778,7 @@ def _reduction(
         tree_node_name=name_comb,
     )
 
-    graph = HighLevelGraph.from_collections(name_agg, mdftr, dependencies=(ph,))
+    graph = HighLevelGraph.from_collections(name_agg, mmstr, dependencies=(ph,))
 
     return AggHistogram(graph, name_agg, histref=ph.histref)
 

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -8,13 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable, Hashable, Literal, Mapping, Seq
 import boost_histogram as bh
 import dask.config
 import numpy as np
-from dask.base import (
-    DaskMethodsMixin,
-    dont_optimize,
-    is_dask_collection,
-    tokenize,
-    unpack_collections,
-)
+from dask.base import DaskMethodsMixin, dont_optimize, is_dask_collection, tokenize
 from dask.blockwise import BlockwiseDep, blockwise, fuse_roots, optimize_blockwise
 from dask.context import globalmethod
 from dask.core import flatten
@@ -324,46 +318,26 @@ def _blocked_dak_ma_w(
 ) -> bh.Histogram:
     import awkward as ak
 
-    tuple_lens = set()
-    for datum in data:
-        if isinstance(datum, tuple):
-            tuple_lens.add(len(datum))
-
-    assert len(tuple_lens) <= 1
-
-    tuple_len = 1 if len(tuple_lens) == 0 else tuple_lens.pop()
+    thedata = [
+        (
+            ak.typetracer.length_zero_if_typetracer(datum)
+            if isinstance(datum, ak.Array)
+            else datum
+        )
+        for datum in data[:-1]
+    ]
+    theweights = (
+        ak.typetracer.length_zero_if_typetracer(data[-1])
+        if isinstance(data[-1], ak.Array)
+        else data[-1]
+    )
 
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
         else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
-
-    for i in range(tuple_len):
-        thedata = []
-        for datum in data[:-1]:
-            thedatum = datum
-            if isinstance(thedatum, tuple):
-                thedatum = thedatum[i]
-            thedatum = (
-                ak.typetracer.length_zero_if_typetracer(thedatum)
-                if isinstance(thedatum, ak.Array)
-                else thedatum
-            )
-            thedata.append(thedatum)
-
-        theweights = data[-1]
-        if isinstance(theweights, tuple):
-            theweights = theweights[i]
-        theweights = (
-            ak.typetracer.length_zero_if_typetracer(theweights)
-            if isinstance(theweights, ak.Array)
-            else theweights
-        )
-
-        thehist.fill(*tuple(thedata), weight=theweights)
-
-    return thehist
+    return thehist.fill(*tuple(thedata), weight=theweights)
 
 
 def _blocked_dak_ma_s(
@@ -918,9 +892,6 @@ def _partitioned_histogram(
     if is_dask_collection(weights):
         _weight_sample_check(*dask_data, weights=weights)
 
-    is_packed = False
-    packed_deps = None
-
     # Single awkward array object.
     if len(data) == 1 and data_is_dak:
         from dask_awkward.lib.core import partitionwise_layer as dak_pwl
@@ -967,47 +938,10 @@ def _partitioned_histogram(
     else:
         # Awkward array collection detected as first argument
         if data_is_dak:
-            from dask_awkward.lib.core import ArgsKwargsPackedFunction as akpf
             from dask_awkward.lib.core import partitionwise_layer as dak_pwl
 
             if weights is not None and sample is None:
-                is_packed = True
-                kwarg_flat_deps, kwarg_repacker = unpack_collections(
-                    {"histref": histref}, traverse=True
-                )
-                arg_flat_deps_expanded = []
-                arg_repackers = []
-                arg_lens_for_repackers = []
-                for arg in [*data, weights]:
-                    this_arg_flat_deps, repacker = unpack_collections(
-                        arg, traverse=True
-                    )
-                    if (
-                        len(this_arg_flat_deps) > 0
-                    ):  # if the deps list is empty this arg does not contain any dask collection, no need to repack!
-                        arg_flat_deps_expanded.extend(this_arg_flat_deps)
-                        arg_repackers.append(repacker)
-                        arg_lens_for_repackers.append(len(this_arg_flat_deps))
-                    else:
-                        arg_flat_deps_expanded.append(arg)
-                        arg_repackers.append(None)
-                        arg_lens_for_repackers.append(1)
-
-                blocked_dak_ma_w_packed = akpf(
-                    _blocked_dak_ma_w,
-                    arg_repackers,
-                    kwarg_repacker,
-                    arg_lens_for_repackers,
-                )
-
-                packed_deps = arg_flat_deps_expanded + kwarg_flat_deps
-
-                g = dak_pwl(
-                    blocked_dak_ma_w_packed,
-                    name,
-                    *arg_flat_deps_expanded,
-                    *kwarg_flat_deps,
-                )
+                g = dak_pwl(_blocked_dak_ma_w, name, *data, weights, histref=histref)
             elif weights is not None and sample is not None:
                 g = dak_pwl(
                     _blocked_dak_ma_w_s,
@@ -1034,8 +968,6 @@ def _partitioned_histogram(
             g = _partitionwise(_blocked_ma, name, *data, histref=histref)
 
     dependencies = _dependencies(*data, weights=weights, sample=sample)
-    if is_packed:
-        dependencies = _dependencies(*packed_deps)
     hlg = HighLevelGraph.from_collections(name, g, dependencies=dependencies)
     return PartitionedHistogram(hlg, name, dask_data[0].npartitions, histref=histref)
 

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -63,7 +63,7 @@ def _blocked_sa(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data)
@@ -83,7 +83,7 @@ def _blocked_sa_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data, sample=sample)
@@ -103,7 +103,7 @@ def _blocked_sa_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data, weight=weights)
@@ -124,7 +124,7 @@ def _blocked_sa_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data, weight=weights, sample=sample)
@@ -142,7 +142,7 @@ def _blocked_ma(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data)
 
@@ -157,7 +157,7 @@ def _blocked_ma_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data, sample=sample)
 
@@ -172,7 +172,7 @@ def _blocked_ma_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data, weight=weights)
 
@@ -188,7 +188,7 @@ def _blocked_ma_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data, weight=weights, sample=sample)
 
@@ -201,7 +201,7 @@ def _blocked_df(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), weight=None)
 
@@ -215,7 +215,7 @@ def _blocked_df_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), sample=sample)
 
@@ -230,7 +230,7 @@ def _blocked_df_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), weight=weights)
 
@@ -246,7 +246,7 @@ def _blocked_df_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), weight=weights, sample=sample)
 
@@ -279,7 +279,7 @@ def _blocked_dak(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(thedata, weight=theweights, sample=thesample)
 
@@ -302,7 +302,7 @@ def _blocked_dak_ma(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*tuple(thedata))
 
@@ -330,7 +330,7 @@ def _blocked_dak_ma_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*tuple(thedata), weight=theweights)
 
@@ -358,7 +358,7 @@ def _blocked_dak_ma_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*tuple(thedata), sample=thesample)
 
@@ -391,7 +391,7 @@ def _blocked_dak_ma_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*tuple(thedata), weight=theweights, sample=thesample)
 
@@ -516,15 +516,11 @@ class AggHistogram(DaskMethodsMixin):
     @property
     def _storage_type(self) -> type[bh.storage.Storage]:
         """Storage type of the histogram."""
-        if isinstance(self.histref, tuple):
-            return self.histref[1]
         return self.histref.storage_type
 
     @property
     def ndim(self) -> int:
         """Total number of dimensions."""
-        if isinstance(self.histref, tuple):
-            return len(self.histref[0])
         return self.histref.ndim
 
     @property
@@ -751,11 +747,6 @@ class PartitionedHistogram(DaskMethodsMixin):
         return [Delayed(k, graph, layer=layer) for k in keys]
 
 
-def _hist_safe_sum(items):
-    safe_items = [item for item in items if not isinstance(item, tuple)]
-    return sum(safe_items)
-
-
 def _reduction(
     ph: PartitionedHistogram,
     split_every: int | None = None,
@@ -772,11 +763,15 @@ def _reduction(
     name_comb = f"{label}-combine-{token}"
     name_agg = f"{label}-agg-{token}"
 
+    def hist_safe_sum(items):
+        safe_items = [item for item in items if not isinstance(item, tuple)]
+        return sum(safe_items)
+
     mdftr = MockableDataFrameTreeReduction(
         name=name_agg,
         name_input=ph.name,
         npartitions_input=ph.npartitions,
-        concat_func=_hist_safe_sum,
+        concat_func=hist_safe_sum,
         tree_node_func=lambda x: x,
         finalize_func=lambda x: x,
         split_every=split_every,
@@ -1006,9 +1001,7 @@ def to_dask_array(agghist: AggHistogram, flow: bool = False, dd: bool = False) -
     thehist = agghist.histref
     if isinstance(thehist, tuple):
         thehist = bh.Histogram(
-            *agghist.histref[0],
-            storage=agghist.histref[1](),
-            metadata=agghist.histref[2],
+            *agghist.histref[0], storage=agghist.histref[1], metadata=agghist.histref[2]
         )
     zeros = (0,) * thehist.ndim
     dsk = {(name, *zeros): (lambda x, f: x.to_numpy(flow=f)[0], agghist.key, flow)}

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -425,27 +425,16 @@ def _blocked_multi_dak(
         weight = None if weights is None else weights[idata]
         sample = None if samples is None else samples[idata]
 
-        thedata = [
-            (
-                ak.typetracer.length_zero_if_typetracer(datum)
-                if isinstance(datum, ak.Array)
-                else datum
-            )
-            for datum in data
-        ]
-        theweight = (
-            ak.typetracer.length_zero_if_typetracer(weight)
-            if isinstance(weight, ak.Array)
-            else weight
-        )
-        thesample = (
-            ak.typetracer.length_zero_if_typetracer(sample)
-            if isinstance(sample, ak.Array)
-            else sample
-        )
-
         if backend != "typetracer":
-            thehist.fill(*tuple(thedata), weight=theweight, sample=thesample)
+            thehist.fill(*tuple(data), weight=weight, sample=sample)
+        else:
+            for datum in data:
+                if isinstance(datum, ak.highlevel.Array):
+                    ak.typetracer.touch_data(datum)
+            if isinstance(weight, ak.highlevel.Array):
+                ak.typetracer.touch_data(weight)
+            if isinstance(sample, ak.highlevel.Array):
+                ak.typetracer.touch_data(sample)
 
     return thehist
 

--- a/src/dask_histogram/layers.py
+++ b/src/dask_histogram/layers.py
@@ -321,7 +321,7 @@ class MockableMultiSourceTreeReduction(Layer):
         return MockableMultiSourceTreeReduction(
             name=self.name,
             names_inputs=self.names_inputs,
-            npartitions_inputs=(1 for _ in self.npartitions_inputs),
+            npartitions_inputs=tuple(1 for _ in self.npartitions_inputs),
             concat_func=self.concat_func,
             tree_node_func=self.tree_node_func,
             finalize_func=self.finalize_func,

--- a/src/dask_histogram/layers.py
+++ b/src/dask_histogram/layers.py
@@ -1,3 +1,12 @@
+from __future__ import annotations
+
+import math
+import operator
+from typing import Any, Callable
+
+import numpy as np
+import toolz
+from dask.highlevelgraph import Layer
 from dask.layers import DataFrameTreeReduction
 
 
@@ -7,6 +16,312 @@ class MockableDataFrameTreeReduction(DataFrameTreeReduction):
             name=self.name,
             name_input=self.name_input,
             npartitions_input=1,
+            concat_func=self.concat_func,
+            tree_node_func=self.tree_node_func,
+            finalize_func=self.finalize_func,
+            split_every=self.split_every,
+            tree_node_name=self.tree_node_name,
+        )
+
+
+class MockableMultiSourceTreeReduction(Layer):
+    """Tree reduction over multiple input collections known to be the
+       same type. This layer can be summed to join over input collections.
+       Mocking is achieved by taking the first partition of each input.
+
+    Parameters
+    ----------
+    name : str
+        Name to use for the constructed layer.
+    names_inputs : tuple[str]
+        Name of the input layers that are being reduced together.
+    npartitions_inputs : tuple[int]
+        Number of partitions in each input layer.
+    concat_func : callable
+        Function used by each tree node to reduce a list of inputs
+        into a single output value. This function must accept only
+        a list as its first positional argument.
+    tree_node_func : callable
+        Function used on the output of ``concat_func`` in each tree
+        node. This function must accept the output of ``concat_func``
+        as its first positional argument.
+    finalize_func : callable, optional
+        Function used in place of ``tree_node_func`` on the final tree
+        node(s) to produce the final output for each split. By default,
+        ``tree_node_func`` will be used.
+    split_every : int, optional
+        This argument specifies the maximum number of input nodes
+        to be handled by any one task in the tree. Defaults to 32.
+    split_out : int, optional
+        This argument specifies the number of output nodes in the
+        reduction tree. If ``split_out`` is set to an integer >=1, the
+        input tasks must contain data that can be indexed by a ``getitem``
+        operation with a key in the range ``[0, split_out)``.
+    output_partitions : list, optional
+        List of required output partitions. This parameter is used
+        internally by Dask for high-level culling.
+    tree_node_name : str, optional
+        Name to use for intermediate tree-node tasks.
+    """
+
+    name: str
+    names_inputs: tuple[str]
+    npartitions_inputs: tuple[int]
+    concat_func: Callable
+    tree_node_func: Callable
+    finalize_func: Callable | None
+    split_every: int
+    split_out: int
+    output_partitions: list[int]
+    tree_node_name: str
+    widths: list[int]
+    height: int
+
+    def __init__(
+        self,
+        name: str,
+        names_inputs: tuple[str],
+        npartitions_inputs: tuple[int],
+        concat_func: Callable,
+        tree_node_func: Callable,
+        finalize_func: Callable | None = None,
+        split_every: int = 32,
+        split_out: int | None = None,
+        output_partitions: list[int] | None = None,
+        tree_node_name: str | None = None,
+        annotations: dict[str, Any] | None = None,
+    ):
+        if len(names_inputs) == 0:
+            raise ValueError("Must specify at least one input!")
+        if len(names_inputs) != len(npartitions_inputs):
+            raise ValueError(
+                "Must specify same number of input collections in names_inputs and npartitions_inputs"
+            )
+
+        super().__init__(annotations=annotations)
+        self.name = name
+        self.names_inputs = names_inputs
+        self.npartitions_inputs = npartitions_inputs
+        self.concat_func = concat_func
+        self.tree_node_func = tree_node_func
+        self.finalize_func = finalize_func
+        self.split_every = split_every
+        self.split_out = split_out  # type: ignore
+        self.output_partitions = (
+            list(range(self.split_out or 1))
+            if output_partitions is None
+            else output_partitions
+        )
+        self.tree_node_name = tree_node_name or "tree_node-" + self.name
+
+        # Calculate tree widths and height
+        # (Used to get output keys without materializing)
+        parts = sum(self.npartitions_inputs)
+        self.widths = [parts]
+        while parts > 1:
+            parts = math.ceil(parts / self.split_every)
+            self.widths.append(int(parts))
+        self.height = len(self.widths)
+
+    def _make_key(self, *name_parts, split=0):
+        # Helper function construct a key
+        # with a "split" element when
+        # bool(split_out) is True
+        return name_parts + (split,) if self.split_out else name_parts
+
+    def _define_task(self, input_keys, final_task=False):
+        # Define nested concatenation and func task
+        if final_task and self.finalize_func:
+            outer_func = self.finalize_func
+        else:
+            outer_func = self.tree_node_func
+        return (toolz.pipe, input_keys, self.concat_func, outer_func)
+
+    def _construct_graph(self):
+        """Construct graph for a tree reduction."""
+
+        dsk = {}
+        if not self.output_partitions:
+            return dsk
+
+        # Deal with `bool(split_out) == True`.
+        # These cases require that the input tasks
+        # return a type that enables getitem operation
+        # with indices: [0, split_out)
+        # Therefore, we must add "getitem" tasks to
+        # select the appropriate element for each split
+        names_inputs_use = self.names_inputs
+        if self.split_out:
+            names_inputs_use = (
+                names_inputs_use + "-split" for names_inputs_use in names_inputs_use
+            )
+            for s in self.output_partitions:
+                for ikey, name_input_use in enumerate(names_inputs_use):
+                    for p in range(self.npartitions_inputs[ikey]):
+                        dsk[self._make_key(name_input_use, p, split=s)] = (
+                            operator.getitem,
+                            (self.names_inputs[ikey], p),
+                            s,
+                        )
+
+        # np.int32 so nothing funny happens on windows
+        input_part_counts = np.array(self.npartitions_inputs, dtype=np.int32)
+        input_names_indices = np.arange(0, len(input_part_counts), dtype=np.int32)
+        input_part_indices = np.concatenate(
+            [
+                np.arange(0, npartitions_input, dtype=np.int32)
+                for npartitions_input in self.npartitions_inputs
+            ],
+            axis=0,
+        )
+        input_names_parents = np.repeat(input_names_indices, input_part_counts)
+        if self.height >= 2:
+            # Loop over output splits
+            for s in self.output_partitions:
+                # Loop over reduction levels
+                for depth in range(1, self.height):
+                    # Loop over reduction groups
+                    for group in range(self.widths[depth]):
+                        # Calculate inputs for the current group
+                        p_max = self.widths[depth - 1]
+                        lstart = self.split_every * group
+                        lstop = min(lstart + self.split_every, p_max)
+                        if depth == 1:
+                            # Input nodes are from input layers
+                            input_keys = [
+                                self._make_key(
+                                    names_inputs_use[input_names_parents[p]],
+                                    input_part_indices[p],
+                                    split=s,
+                                )
+                                for p in range(lstart, lstop)
+                            ]
+                        else:
+                            # Input nodes are tree-reduction nodes
+                            input_keys = [
+                                self._make_key(
+                                    self.tree_node_name, p, depth - 1, split=s
+                                )
+                                for p in range(lstart, lstop)
+                            ]
+
+                        # Define task
+                        if depth == self.height - 1:
+                            # Final Node (Use fused `self.tree_finalize` task)
+                            assert (
+                                group == 0
+                            ), f"group = {group}, not 0 for final tree reduction task"
+                            dsk[(self.name, s)] = self._define_task(
+                                input_keys, final_task=True
+                            )
+                        else:
+                            # Intermediate Node
+                            dsk[
+                                self._make_key(
+                                    self.tree_node_name, group, depth, split=s
+                                )
+                            ] = self._define_task(input_keys, final_task=False)
+        else:
+            # Deal with single-partition case
+            for s in self.output_partitions:
+                input_keys = [self._make_key(names_inputs_use[0], 0, split=s)]
+                dsk[(self.name, s)] = self._define_task(input_keys, final_task=True)
+
+        return dsk
+
+    def __repr__(self):
+        return "MockableMultiSourceTreeReduction<name='{}', input_names={}, split_out={}>".format(
+            self.name, self.names_inputs, self.split_out
+        )
+
+    def _output_keys(self):
+        return {(self.name, s) for s in self.output_partitions}
+
+    def get_output_keys(self):
+        if hasattr(self, "_cached_output_keys"):
+            return self._cached_output_keys
+        else:
+            output_keys = self._output_keys()
+            self._cached_output_keys = output_keys
+        return self._cached_output_keys
+
+    def is_materialized(self):
+        return hasattr(self, "_cached_dict")
+
+    @property
+    def _dict(self):
+        """Materialize full dict representation"""
+        if hasattr(self, "_cached_dict"):
+            return self._cached_dict
+        else:
+            dsk = self._construct_graph()
+            self._cached_dict = dsk
+        return self._cached_dict
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        # Start with "base" tree-reduction size
+        tree_size = (sum(self.widths[1:]) or 1) * (self.split_out or 1)
+        if self.split_out:
+            # Add on "split-*" tasks used for `getitem` ops
+            return tree_size + sum(self.npartitions_inputs, 0) * len(
+                self.output_partitions
+            )
+        return tree_size
+
+    def _keys_to_output_partitions(self, keys):
+        """Simple utility to convert keys to output partition indices."""
+        splits = set()
+        for key in keys:
+            try:
+                _name, _split = key
+            except ValueError:
+                continue
+            if _name != self.name:
+                continue
+            splits.add(_split)
+        return splits
+
+    def _cull(self, output_partitions):
+        return MockableMultiSourceTreeReduction(
+            self.name,
+            self.names_inputs,
+            self.npartitions_inputs,
+            self.concat_func,
+            self.tree_node_func,
+            finalize_func=self.finalize_func,
+            split_every=self.split_every,
+            split_out=self.split_out,
+            output_partitions=output_partitions,
+            tree_node_name=self.tree_node_name,
+            annotations=self.annotations,
+        )
+
+    def cull(self, keys, all_keys):
+        """Cull a MockableMultiSourceTreeReduction HighLevelGraph layer"""
+        input_names = set()
+        for i in range(len(self.names_inputs)):
+            input_names.update(
+                {(self.names_inputs[i], k) for k in range(self.npartitions_inputs[i])}
+            )
+        deps = {(self.name, 0): input_names}
+        output_partitions = self._keys_to_output_partitions(keys)
+        if output_partitions != set(self.output_partitions):
+            culled_layer = self._cull(output_partitions)
+            return culled_layer, deps
+        else:
+            return self, deps
+
+    def mock(self):
+        return MockableMultiSourceTreeReduction(
+            name=self.name,
+            names_inputs=self.names_inputs,
+            npartitions_inputs=(1 for _ in self.npartitions_inputs),
             concat_func=self.concat_func,
             tree_node_func=self.tree_node_func,
             finalize_func=self.finalize_func,

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -184,7 +184,6 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
 
     for i in range(25):
         h.fill(f"testcat{i+1}", i + 1, x, y, z, weight=weights[i] if weights else None)
-    h.visualize(filename="check_graph.pdf")
     h = h.compute()
 
     control = bh.Histogram(*h.axes, storage=h.storage_type())

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -175,7 +175,7 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
         storage=storage,
     )
 
-    # check that we are using the correct optimizer
+    # check that we are using the correct optimize
     assert h.__dask_optimize__ == dak.lib.optimize.all_optimizations
 
     for i in range(25):

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -127,28 +127,26 @@ def test_obj_5D_strcat_intcat_rectangular(use_weights):
         dhb.axis.Regular(9, -3.2, 3.2),
         storage=storage,
     )
-    for i in range(25):
-        h.fill(f"testcat{i+1}", i + 1, *(x.T), weight=weights)
+    h.fill("testcat1", 1, *(x.T), weight=weights)
+    h.fill("testcat2", 2, *(x.T), weight=weights)
     h = h.compute()
 
     control = bh.Histogram(*h.axes, storage=h.storage_type())
     if use_weights:
-        for i in range(25):
-            control.fill(
-                f"testcat{i+1}", i + 1, *(x.compute().T), weight=weights.compute()
-            )
+        control.fill("testcat1", 1, *(x.compute().T), weight=weights.compute())
+        control.fill("testcat2", 2, *(x.compute().T), weight=weights.compute())
     else:
-        for i in range(25):
-            control.fill(f"testcat{i+1}", i + 1, *(x.compute().T))
+        control.fill("testcat1", 1, *(x.compute().T))
+        control.fill("testcat2", 2, *(x.compute().T))
 
     assert np.allclose(h.counts(), control.counts())
     if use_weights:
         assert np.allclose(h.variances(), control.variances())
 
-    assert len(h.axes[0]) == 25 and len(control.axes[0]) == 25
+    assert len(h.axes[0]) == 2 and len(control.axes[0]) == 2
     assert all(cx == hx for cx, hx in zip(control.axes[0], h.axes[0]))
 
-    assert len(h.axes[1]) == 25 and len(control.axes[1]) == 25
+    assert len(h.axes[1]) == 2 and len(control.axes[1]) == 2
     assert all(cx == hx for cx, hx in zip(control.axes[1], h.axes[1]))
 
 

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -159,10 +159,12 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
     x = dak.from_dask_array(da.random.standard_normal(size=2000, chunks=400))
     y = dak.from_dask_array(da.random.standard_normal(size=2000, chunks=400))
     z = dak.from_dask_array(da.random.standard_normal(size=2000, chunks=400))
+    weights = []
     if use_weights:
-        weights = dak.from_dask_array(
-            da.random.uniform(0.5, 0.75, size=2000, chunks=400)
-        )
+        for i in range(25):
+            weights.append(
+                dak.from_dask_array(da.random.uniform(0.5, 0.75, size=2000, chunks=400))
+            )
         storage = dhb.storage.Weight()
     else:
         weights = None
@@ -181,7 +183,8 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
     assert h.__dask_optimize__ == dak.lib.optimize.all_optimizations
 
     for i in range(25):
-        h.fill(f"testcat{i+1}", i + 1, x, y, z, weight=weights)
+        h.fill(f"testcat{i+1}", i + 1, x, y, z, weight=weights[i] if weights else None)
+    h.visualize(filename="check_graph.pdf")
     h = h.compute()
 
     control = bh.Histogram(*h.axes, storage=h.storage_type())
@@ -189,7 +192,7 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
     if use_weights:
         for i in range(25):
             control.fill(
-                f"testcat{i+1}", i + 1, x_c, y_c, z_c, weight=weights.compute()
+                f"testcat{i+1}", i + 1, x_c, y_c, z_c, weight=weights[i].compute()
             )
     else:
         for i in range(25):

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -127,26 +127,28 @@ def test_obj_5D_strcat_intcat_rectangular(use_weights):
         dhb.axis.Regular(9, -3.2, 3.2),
         storage=storage,
     )
-    h.fill("testcat1", 1, *(x.T), weight=weights)
-    h.fill("testcat2", 2, *(x.T), weight=weights)
+    for i in range(25):
+        h.fill(f"testcat{i+1}", i + 1, *(x.T), weight=weights)
     h = h.compute()
 
     control = bh.Histogram(*h.axes, storage=h.storage_type())
     if use_weights:
-        control.fill("testcat1", 1, *(x.compute().T), weight=weights.compute())
-        control.fill("testcat2", 2, *(x.compute().T), weight=weights.compute())
+        for i in range(25):
+            control.fill(
+                f"testcat{i+1}", i + 1, *(x.compute().T), weight=weights.compute()
+            )
     else:
-        control.fill("testcat1", 1, *(x.compute().T))
-        control.fill("testcat2", 2, *(x.compute().T))
+        for i in range(25):
+            control.fill(f"testcat{i+1}", i + 1, *(x.compute().T))
 
     assert np.allclose(h.counts(), control.counts())
     if use_weights:
         assert np.allclose(h.variances(), control.variances())
 
-    assert len(h.axes[0]) == 2 and len(control.axes[0]) == 2
+    assert len(h.axes[0]) == 25 and len(control.axes[0]) == 25
     assert all(cx == hx for cx, hx in zip(control.axes[0], h.axes[0]))
 
-    assert len(h.axes[1]) == 2 and len(control.axes[1]) == 2
+    assert len(h.axes[1]) == 25 and len(control.axes[1]) == 25
     assert all(cx == hx for cx, hx in zip(control.axes[1], h.axes[1]))
 
 
@@ -175,7 +177,7 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
         storage=storage,
     )
 
-    # check that we are using the correct optimize
+    # check that we are using the correct optimizer
     assert h.__dask_optimize__ == dak.lib.optimize.all_optimizations
 
     for i in range(25):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,13 +12,13 @@ import dask_histogram.core as dhc
 
 def _gen_storage(weights, sample):
     if weights is not None and sample is not None:
-        store = bh.storage.WeightedMean
+        store = bh.storage.WeightedMean()
     elif weights is None and sample is not None:
-        store = bh.storage.Mean
+        store = bh.storage.Mean()
     elif weights is not None and sample is None:
-        store = bh.storage.Weight
+        store = bh.storage.Weight()
     else:
-        store = bh.storage.Double
+        store = bh.storage.Double()
     return store
 
 
@@ -31,7 +31,7 @@ def test_1d_array(weights, sample):
         sample = da.random.uniform(2, 8, size=(2000,), chunks=(250,))
     store = _gen_storage(weights, sample)
     histref = ((bh.axis.Regular(10, -3, 3),), store, None)
-    h = bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+    h = bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     x = da.random.standard_normal(size=(2000,), chunks=(250,))
     dh = dhc.factory(x, histref=histref, weights=weights, split_every=4, sample=sample)
     h.fill(
@@ -59,7 +59,7 @@ def test_array_input(weights, shape, sample):
         sample = da.random.uniform(3, 9, size=(2000,), chunks=(200,))
     store = _gen_storage(weights, sample)
     histref = (axes, store, None)
-    h = bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+    h = bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     dh = dhc.factory(x, histref=histref, weights=weights, split_every=4, sample=sample)
     h.fill(
         *xc,
@@ -76,12 +76,12 @@ def test_multi_array(weights):
             bh.axis.Regular(10, -3, 3),
             bh.axis.Regular(10, -3, 3),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     h = bh.Histogram(
         *histref[0],
-        storage=histref[1](),
+        storage=histref[1],
         metadata=histref[2],
     )
     if weights is not None:
@@ -105,12 +105,12 @@ def test_nd_array(weights):
             bh.axis.Regular(10, 0, 1),
             bh.axis.Regular(10, 0, 1),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     h = bh.Histogram(
         *histref[0],
-        storage=histref[1](),
+        storage=histref[1],
         metadata=histref[2],
     )
     if weights is not None:
@@ -134,10 +134,10 @@ def test_df_input(weights):
             bh.axis.Regular(12, 0, 1),
             bh.axis.Regular(12, 0, 1),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
-    h = bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+    h = bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     df = dds.timeseries(freq="600s", partition_freq="2d")
     dfc = df.compute()
     if weights is not None:
@@ -166,7 +166,7 @@ def test_to_dask_array(weights, shape):
     )
     h = bh.Histogram(*axes, storage=bh.storage.Weight())
     dh = dhc.factory(
-        x, histref=(axes, bh.storage.Weight, None), weights=weights, split_every=4
+        x, histref=(axes, bh.storage.Weight(), None), weights=weights, split_every=4
     )
     h.fill(*xc, weight=weights.compute() if weights is not None else None)
     c, _ = dh.to_dask_array(flow=False, dd=True)
@@ -181,7 +181,7 @@ def gen_hist_1D(
 ) -> dhc.AggHistogram:
     histref = (
         (bh.axis.Regular(bins, range[0], range[1]),),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     x = da.random.standard_normal(size=size, chunks=chunks)
@@ -319,12 +319,12 @@ def test_agghist_to_delayed(weights):
             bh.axis.Regular(10, 0, 1),
             bh.axis.Regular(10, 0, 1),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     h = bh.Histogram(
         *histref[0],
-        storage=histref[1](),
+        storage=histref[1],
         metadata=histref[2],
     )
     if weights is not None:


### PR DESCRIPTION
This is definitely a prototype - but outlines a nice pattern allows the interface to scale a littler further.

This results in significantly simpler graphs for single histograms with lots of fills (i.e. over systematic uncertainty categories).
Now, instead of multiple layers of tree reduces for boost histograms there is just one that aggregates over all `hist-on-block` operations that are generated on each histogram fill. i.e. This can handle a tree reduce over multiple input collections.

Memory use is a little bit less. Graph is pleasantly more clean.

before:
![starting_graph](https://github.com/dask-contrib/dask-histogram/assets/1068089/5fa56373-44ed-442c-8bfb-10726871f791)

after:
![with_new_agg](https://github.com/dask-contrib/dask-histogram/assets/1068089/f43217d9-5cb8-4f8e-9e79-7d5b65c532ca)

It may not look like a big diff with a smaller graph but it becomes very apparent as you increase the number of fills.

~~This PR also now implements multi-fill syntax.~~ With a more concise implementation this appears to not be necessary.
