### PR TITLE
feat!: when filling dask_histgram.boost.Histograms delay creation of task graph, use multi-fill

### DIFF
--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -110,11 +110,9 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         )
 
     def __iadd__(self, other):
-        if self.staged_fills() and other.staged_fills():
-            self._staged += other._staged
-        elif not self.staged_fills() and other.staged_fills():
-            self._staged = other._staged
-        return self
+        raise NotImplementedError(
+            "dask-boost-histograms are not addable, please sum them after computation!"
+        )
 
     def __add__(self, other):
         return self.__iadd__(other)

--- a/src/dask_histogram/boost.py
+++ b/src/dask_histogram/boost.py
@@ -297,13 +297,12 @@ class Histogram(bh.Histogram, DaskMethodsMixin, family=dask_histogram):
         else:
             raise ValueError(f"Cannot interpret input data: {args}")
 
-        # new_fill = partitioned_factory(*args, histref=self._histref, weights=weight, sample=sample)
         new_fill = {"args": args, "kwargs": {"weight": weight, "sample": sample}}
         if self._staged is None:
             self._staged = [new_fill]
         else:
             self._staged.append(new_fill)
-        self._dask = None  # self._staged.__dask_graph__()
+        self._dask = None
         self._dask_name = "__not_yet_calculated__"
 
         return self

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -984,11 +984,12 @@ def _partitioned_histogram_multifill(
     name = f"hist-on-block-{tokenize(data, histref, weights, samples)}"
 
     from dask.base import unpack_collections
-    from dask_awkward.lib.core import partitionwise_layer as dak_pwl
 
     flattened_deps, repacker = unpack_collections(data, weights, samples, histref)
 
     if is_dask_awkward_like(flattened_deps[0]):
+        from dask_awkward.lib.core import partitionwise_layer as dak_pwl
+
         unpacked_multifill = partial(_blocked_multi_dak, repacker)
         graph = dak_pwl(unpacked_multifill, name, *flattened_deps)
     elif is_dataframe_like(flattened_deps[0]):

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -35,8 +35,7 @@ __all__ = (
 
 
 def hist_safe_sum(items):
-    safe_items = [item for item in items if not isinstance(item, tuple)]
-    return sum(safe_items)
+    return sum(item for item in items if not isinstance(item, tuple))
 
 
 def clone(histref: bh.Histogram | None = None) -> bh.Histogram:

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -14,6 +14,7 @@ from dask.context import globalmethod
 from dask.core import flatten
 from dask.delayed import Delayed
 from dask.highlevelgraph import HighLevelGraph
+from dask.local import identity
 from dask.threaded import get as tget
 from dask.utils import is_dataframe_like, key_split
 
@@ -30,6 +31,11 @@ __all__ = (
     "clone",
     "factory",
 )
+
+
+def hist_safe_sum(items):
+    safe_items = [item for item in items if not isinstance(item, tuple)]
+    return sum(safe_items)
 
 
 def clone(histref: bh.Histogram | None = None) -> bh.Histogram:
@@ -63,7 +69,7 @@ def _blocked_sa(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data)
@@ -83,7 +89,7 @@ def _blocked_sa_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data, sample=sample)
@@ -103,7 +109,7 @@ def _blocked_sa_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data, weight=weights)
@@ -124,7 +130,7 @@ def _blocked_sa_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     if data.ndim == 1:
         return thehist.fill(data, weight=weights, sample=sample)
@@ -142,7 +148,7 @@ def _blocked_ma(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data)
 
@@ -157,7 +163,7 @@ def _blocked_ma_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data, sample=sample)
 
@@ -172,7 +178,7 @@ def _blocked_ma_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data, weight=weights)
 
@@ -188,7 +194,7 @@ def _blocked_ma_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*data, weight=weights, sample=sample)
 
@@ -201,7 +207,7 @@ def _blocked_df(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), weight=None)
 
@@ -215,7 +221,7 @@ def _blocked_df_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), sample=sample)
 
@@ -230,7 +236,7 @@ def _blocked_df_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), weight=weights)
 
@@ -246,7 +252,7 @@ def _blocked_df_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*(data[c] for c in data.columns), weight=weights, sample=sample)
 
@@ -279,7 +285,7 @@ def _blocked_dak(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(thedata, weight=theweights, sample=thesample)
 
@@ -302,7 +308,7 @@ def _blocked_dak_ma(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*tuple(thedata))
 
@@ -330,9 +336,13 @@ def _blocked_dak_ma_w(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
-    return thehist.fill(*tuple(thedata), weight=theweights)
+
+    if ak.backend(*data) != "typetracer":
+        thehist.fill(*tuple(thedata), weight=theweights)
+
+    return thehist
 
 
 def _blocked_dak_ma_s(
@@ -358,7 +368,7 @@ def _blocked_dak_ma_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*tuple(thedata), sample=thesample)
 
@@ -391,9 +401,43 @@ def _blocked_dak_ma_w_s(
     thehist = (
         clone(histref)
         if not isinstance(histref, tuple)
-        else bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     )
     return thehist.fill(*tuple(thedata), weight=theweights, sample=thesample)
+
+
+def _blocked_multi_dak(
+    data_list: tuple[tuple[Any]],
+    weights: tuple[Any] | None,
+    samples: tuple[Any] | None,
+    histref: tuple | bh.Histogram | None = None,
+) -> bh.Histogram:
+    import awkward as ak
+
+    thehist = (
+        clone(histref)
+        if not isinstance(histref, tuple)
+        else bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
+    )
+
+    backend = ak.backend(*data_list[0])
+
+    for idata, data in enumerate(data_list):
+        weight = None if weights is None else weights[idata]
+        sample = None if samples is None else samples[idata]
+
+        if backend != "typetracer":
+            thehist.fill(*data, weight=weight, sample=sample)
+        else:
+            for datum in data:
+                if isinstance(datum, ak.highlevel.Array):
+                    ak.typetracer.touch_data(datum)
+            if isinstance(weight, ak.highlevel.Array):
+                ak.typetracer.touch_data(weight)
+            if isinstance(sample, ak.highlevel.Array):
+                ak.typetracer.touch_data(sample)
+
+    return thehist
 
 
 def optimize(
@@ -516,15 +560,11 @@ class AggHistogram(DaskMethodsMixin):
     @property
     def _storage_type(self) -> type[bh.storage.Storage]:
         """Storage type of the histogram."""
-        if isinstance(self.histref, tuple):
-            return self.histref[1]
         return self.histref.storage_type
 
     @property
     def ndim(self) -> int:
         """Total number of dimensions."""
-        if isinstance(self.histref, tuple):
-            return len(self.histref[0])
         return self.histref.ndim
 
     @property
@@ -751,17 +791,12 @@ class PartitionedHistogram(DaskMethodsMixin):
         return [Delayed(k, graph, layer=layer) for k in keys]
 
 
-def _hist_safe_sum(items):
-    safe_items = [item for item in items if not isinstance(item, tuple)]
-    return sum(safe_items)
-
-
 def _reduction(
     ph: PartitionedHistogram,
     split_every: int | None = None,
 ) -> AggHistogram:
     if split_every is None:
-        split_every = dask.config.get("histogram.aggregation.split_every", 8)
+        split_every = dask.config.get("histogram.aggregation.split-every", 8)
     if split_every is False:
         split_every = ph.npartitions
 
@@ -776,9 +811,9 @@ def _reduction(
         name=name_agg,
         name_input=ph.name,
         npartitions_input=ph.npartitions,
-        concat_func=_hist_safe_sum,
-        tree_node_func=lambda x: x,
-        finalize_func=lambda x: x,
+        concat_func=hist_safe_sum,
+        tree_node_func=identity,
+        finalize_func=identity,
         split_every=split_every,
         tree_node_name=name_comb,
     )
@@ -875,6 +910,35 @@ def _partitionwise(func, layer_name, *args, **kwargs):
         numblocks=numblocks,
         concatenate=True,
         **kwargs,
+    )
+
+
+class PackedMultifill:
+    def __init__(self, repacker):
+        self.repacker = repacker
+
+    def __call__(self, *args):
+        return _blocked_multi_dak(*self.repacker(args))
+
+
+def _partitioned_histogram_multifill(
+    data: tuple[DaskCollection | tuple],
+    histref: bh.Histogram | tuple,
+    weights: tuple[DaskCollection] | None = None,
+    samples: tuple[DaskCollection] | None = None,
+):
+    name = f"hist-on-block-{tokenize(data, histref, weights, samples)}"
+
+    from dask.base import unpack_collections
+    from dask_awkward.lib.core import partitionwise_layer as dak_pwl
+
+    flattened_deps, repacker = unpack_collections(data, weights, samples, histref)
+
+    graph = dak_pwl(PackedMultifill(repacker), name, *flattened_deps)
+
+    hlg = HighLevelGraph.from_collections(name, graph, dependencies=flattened_deps)
+    return PartitionedHistogram(
+        hlg, name, flattened_deps[0].npartitions, histref=histref
     )
 
 
@@ -1006,9 +1070,7 @@ def to_dask_array(agghist: AggHistogram, flow: bool = False, dd: bool = False) -
     thehist = agghist.histref
     if isinstance(thehist, tuple):
         thehist = bh.Histogram(
-            *agghist.histref[0],
-            storage=agghist.histref[1](),
-            metadata=agghist.histref[2],
+            *agghist.histref[0], storage=agghist.histref[1], metadata=agghist.histref[2]
         )
     zeros = (0,) * thehist.ndim
     dsk = {(name, *zeros): (lambda x, f: x.to_numpy(flow=f)[0], agghist.key, flow)}

--- a/src/dask_histogram/histogram.yaml
+++ b/src/dask_histogram/histogram.yaml
@@ -7,4 +7,4 @@ histogram:
     # aggregated histogram this parameter controls how the tree
     # reduction is handled; this number of nodes will be combined at a
     # time as a new dask task.
-    split_every: 8
+    split-every: 8

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -159,10 +159,12 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
     x = dak.from_dask_array(da.random.standard_normal(size=2000, chunks=400))
     y = dak.from_dask_array(da.random.standard_normal(size=2000, chunks=400))
     z = dak.from_dask_array(da.random.standard_normal(size=2000, chunks=400))
+    weights = []
     if use_weights:
-        weights = dak.from_dask_array(
-            da.random.uniform(0.5, 0.75, size=2000, chunks=400)
-        )
+        for i in range(25):
+            weights.append(
+                dak.from_dask_array(da.random.uniform(0.5, 0.75, size=2000, chunks=400))
+            )
         storage = dhb.storage.Weight()
     else:
         weights = None
@@ -181,7 +183,7 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
     assert h.__dask_optimize__ == dak.lib.optimize.all_optimizations
 
     for i in range(25):
-        h.fill(f"testcat{i+1}", i + 1, x, y, z, weight=weights)
+        h.fill(f"testcat{i+1}", i + 1, x, y, z, weight=weights[i] if weights else None)
     h = h.compute()
 
     control = bh.Histogram(*h.axes, storage=h.storage_type())
@@ -189,7 +191,7 @@ def test_obj_5D_strcat_intcat_rectangular_dak(use_weights):
     if use_weights:
         for i in range(25):
             control.fill(
-                f"testcat{i+1}", i + 1, x_c, y_c, z_c, weight=weights.compute()
+                f"testcat{i+1}", i + 1, x_c, y_c, z_c, weight=weights[i].compute()
             )
     else:
         for i in range(25):

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -485,14 +485,19 @@ def test_add(use_weights):
     h2 = dhb.Histogram(dhb.axis.Regular(12, -3, 3), storage=store())
     h2.fill(y, weight=yweights)
 
-    h3 = h1 + h2
+    with pytest.raises(NotImplementedError):
+        h3 = h1 + h2
 
-    h3 = h3.compute()
+    h3 = h1.compute() + h2.compute()
 
     h4 = dhb.Histogram(dhb.axis.Regular(12, -3, 3), storage=store())
     h4.fill(x, weight=xweights)
-    h4 += h2
+
+    with pytest.raises(NotImplementedError):
+        h4 += h2
+
     h4 = h4.compute()
+    h4 += h2.compute()
 
     controlx = bh.Histogram(*h1.axes, storage=h1.storage_type())
     controly = bh.Histogram(*h2.axes, storage=h2.storage_type())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,13 +12,13 @@ import dask_histogram.core as dhc
 
 def _gen_storage(weights, sample):
     if weights is not None and sample is not None:
-        store = bh.storage.WeightedMean
+        store = bh.storage.WeightedMean()
     elif weights is None and sample is not None:
-        store = bh.storage.Mean
+        store = bh.storage.Mean()
     elif weights is not None and sample is None:
-        store = bh.storage.Weight
+        store = bh.storage.Weight()
     else:
-        store = bh.storage.Double
+        store = bh.storage.Double()
     return store
 
 
@@ -31,7 +31,7 @@ def test_1d_array(weights, sample):
         sample = da.random.uniform(2, 8, size=(2000,), chunks=(250,))
     store = _gen_storage(weights, sample)
     histref = ((bh.axis.Regular(10, -3, 3),), store, None)
-    h = bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+    h = bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     x = da.random.standard_normal(size=(2000,), chunks=(250,))
     dh = dhc.factory(x, histref=histref, weights=weights, split_every=4, sample=sample)
     h.fill(
@@ -59,7 +59,7 @@ def test_array_input(weights, shape, sample):
         sample = da.random.uniform(3, 9, size=(2000,), chunks=(200,))
     store = _gen_storage(weights, sample)
     histref = (axes, store, None)
-    h = bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+    h = bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     dh = dhc.factory(x, histref=histref, weights=weights, split_every=4, sample=sample)
     h.fill(
         *xc,
@@ -76,12 +76,12 @@ def test_multi_array(weights):
             bh.axis.Regular(10, -3, 3),
             bh.axis.Regular(10, -3, 3),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     h = bh.Histogram(
         *histref[0],
-        storage=histref[1](),
+        storage=histref[1],
         metadata=histref[2],
     )
     if weights is not None:
@@ -105,12 +105,12 @@ def test_nd_array(weights):
             bh.axis.Regular(10, 0, 1),
             bh.axis.Regular(10, 0, 1),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     h = bh.Histogram(
         *histref[0],
-        storage=histref[1](),
+        storage=histref[1],
         metadata=histref[2],
     )
     if weights is not None:
@@ -134,10 +134,10 @@ def test_df_input(weights):
             bh.axis.Regular(12, 0, 1),
             bh.axis.Regular(12, 0, 1),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
-    h = bh.Histogram(*histref[0], storage=histref[1](), metadata=histref[2])
+    h = bh.Histogram(*histref[0], storage=histref[1], metadata=histref[2])
     df = dds.timeseries(freq="600s", partition_freq="2d")
     dfc = df.compute()
     if weights is not None:
@@ -166,7 +166,7 @@ def test_to_dask_array(weights, shape):
     )
     h = bh.Histogram(*axes, storage=bh.storage.Weight())
     dh = dhc.factory(
-        x, histref=(axes, bh.storage.Weight, None), weights=weights, split_every=4
+        x, histref=(axes, bh.storage.Weight(), None), weights=weights, split_every=4
     )
     h.fill(*xc, weight=weights.compute() if weights is not None else None)
     c, _ = dh.to_dask_array(flow=False, dd=True)
@@ -181,7 +181,7 @@ def gen_hist_1D(
 ) -> dhc.AggHistogram:
     histref = (
         (bh.axis.Regular(bins, range[0], range[1]),),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     x = da.random.standard_normal(size=size, chunks=chunks)
@@ -319,12 +319,12 @@ def test_agghist_to_delayed(weights):
             bh.axis.Regular(10, 0, 1),
             bh.axis.Regular(10, 0, 1),
         ),
-        bh.storage.Weight,
+        bh.storage.Weight(),
         None,
     )
     h = bh.Histogram(
         *histref[0],
-        storage=histref[1](),
+        storage=histref[1],
         metadata=histref[2],
     )
     if weights is not None:


### PR DESCRIPTION
Closes #126  (supercedes, github was stuck)

Refer to that PR for justification.

This PR implements:
- reverts the current tree reduce pattern for filling dask-boost-histograms
- delayed generation of dask-boost-histogram taskgraphs
- multi-fills where in the case of dask-awkward array inputs all fills to a histogram are grouped into a single task
  - this is implemented as a tree reduce