### PR TITLE
Fix docs building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,24 @@ complete = [
     "hist",
     "pytest",
     "sphinx >=4.0.0",
+    "sphinxcontrib-applehelp>=1.0.0,<1.0.7",
+    "sphinxcontrib-devhelp>=1.0.0,<1.0.6",
+    "sphinxcontrib-htmlhelp>=2.0.0,<2.0.5",
+    "sphinxcontrib-serializinghtml>=1.1.0,<1.1.10",
+    "sphinxcontrib-qthelp>=1.0.0,<1.0.7",
 ]
 docs = [
     "dask-sphinx-theme >=3.0.2",
     "dask[array,dataframe]",
     "dask-awkward >=2023.10.0",
+    # FIXME: `sphinxcontrib-*` pins are a workaround until we have sphinx>=5.
+    #        See https://github.com/dask/dask-sphinx-theme/issues/68.
     "sphinx >=4.0.0",
+    "sphinxcontrib-applehelp>=1.0.0,<1.0.7",
+    "sphinxcontrib-devhelp>=1.0.0,<1.0.6",
+    "sphinxcontrib-htmlhelp>=2.0.0,<2.0.5",
+    "sphinxcontrib-serializinghtml>=1.1.0,<1.1.10",
+    "sphinxcontrib-qthelp>=1.0.0,<1.0.7",
 ]
 test = [
     "dask[array,dataframe]",


### PR DESCRIPTION
Building the docs fails due to dask-sphinx-theme pinning `sphinx-book-theme==0.2`. See https://github.com/dask/dask-sphinx-theme/issues/68.

By applying the workaround of pinning sphinx-contrib packages as suggested in the thread, and as done by the [main Dask docs](https://github.com/dask/dask/blob/main/docs/requirements-docs.txt), the documentation should build.
I could build it locally with python 3.11, it seemed ok.
