### PR TITLE
[fix] import dak if it exists

### DIFF
--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -526,10 +526,12 @@ def _get_optimization_function():
     # detected then the original graph is returned unchanged.
     import importlib.metadata
 
-    if importlib.metadata.distribution("dask_awkward"):
+    try:
         from dask_awkward.lib.optimize import all_optimizations
 
         return all_optimizations
+    except (ImportError, ModuleNotFoundError):
+        pass
     return optimize
 
 

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -524,8 +524,6 @@ def _get_optimization_function():
     # running this optimization even in cases where it's unncessary
     # because if no AwkwardInputLayers from dask-awkward are
     # detected then the original graph is returned unchanged.
-    import importlib.metadata
-
     try:
         from dask_awkward.lib.optimize import all_optimizations
 

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -524,7 +524,9 @@ def _get_optimization_function():
     # running this optimization even in cases where it's unncessary
     # because if no AwkwardInputLayers from dask-awkward are
     # detected then the original graph is returned unchanged.
-    if dask.config.get("awkward", default=False):
+    import importlib.metadata
+
+    if importlib.metadata.distribution("dask_awkward"):
         from dask_awkward.lib.optimize import all_optimizations
 
         return all_optimizations


### PR DESCRIPTION
This ensures we get dak's optimisations. Previously we checked to see if it was already imported, but since https://github.com/dask-contrib/dask-awkward/pull/546 , dask doesn't import dask-awkward while it is being imported.