### PR TITLE
Store histref in a partial function for propagation through graph.

### DIFF
--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -1026,9 +1026,17 @@ def _partitioned_histogram(
     # Single awkward array object.
     if len(data) == 1 and data_is_dak:
         from dask_awkward.lib.core import partitionwise_layer as dak_pwl
+        f = partial(_blocked_dak, histref=histref)
 
-        f = partial(_blocked_dak, weights=weights, sample=sample, histref=histref)
-        g = dak_pwl(f, name, data[0])
+        x = data[0]
+        if weights is not None and sample is not None:
+            g = dak_pwl(f, name, x, weights, sample)
+        elif weights is not None and sample is None:
+            g = dak_pwl(f, name, x, weights, None)
+        elif weights is None and sample is not None:
+            g = dak_pwl(f,  name, x, None, sample)
+        else:
+            g = dak_pwl(f, name, x, None, None)
 
     # Single object, not a dataframe
     elif len(data) == 1 and not data_is_df:

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -410,7 +410,6 @@ def _blocked_multi(
     repacker: Callable,
     *flattened_inputs: tuple[Any],
 ) -> bh.Histogram:
-
     data_list, weights, samples, histref = repacker(flattened_inputs)
 
     weights = weights or (None for _ in range(len(data_list)))
@@ -439,7 +438,6 @@ def _blocked_multi_df(
     repacker: Callable,
     *flattened_inputs: tuple[Any],
 ) -> bh.Histogram:
-
     data_list, weights, samples, histref = repacker(flattened_inputs)
 
     weights = weights or (None for _ in range(len(data_list)))

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -1027,15 +1027,7 @@ def _partitioned_histogram(
 
         f = partial(_blocked_dak, histref=histref)
 
-        x = data[0]
-        if weights is not None and sample is not None:
-            g = dak_pwl(f, name, x, weights, sample)
-        elif weights is not None and sample is None:
-            g = dak_pwl(f, name, x, weights, None)
-        elif weights is None and sample is not None:
-            g = dak_pwl(f, name, x, None, sample)
-        else:
-            g = dak_pwl(f, name, x, None, None)
+        g = dak_pwl(f, name, data[0], weights, sample)
 
     # Single object, not a dataframe
     elif len(data) == 1 and not data_is_df:

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -1026,6 +1026,7 @@ def _partitioned_histogram(
     # Single awkward array object.
     if len(data) == 1 and data_is_dak:
         from dask_awkward.lib.core import partitionwise_layer as dak_pwl
+
         f = partial(_blocked_dak, histref=histref)
 
         x = data[0]
@@ -1034,7 +1035,7 @@ def _partitioned_histogram(
         elif weights is not None and sample is None:
             g = dak_pwl(f, name, x, weights, None)
         elif weights is None and sample is not None:
-            g = dak_pwl(f,  name, x, None, sample)
+            g = dak_pwl(f, name, x, None, sample)
         else:
             g = dak_pwl(f, name, x, None, None)
 

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -584,3 +584,20 @@ def test_155_boost_factory():
         axes=(axis,),
     ).compute()
     assert np.all(hist.values() == [3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0])
+
+
+def test_155_2():
+    import boost_histogram as bh
+    import dask_awkward as dak
+    import dask_histogram as dh
+
+    arr = dak.from_lists([list(range(10))] * 3)
+    axis = bh.axis.Regular(10, 0.0, 10.0)
+    hist = dh.factory(
+        arr,
+        axes=(axis,),
+        weights=arr,
+    ).compute()
+    assert np.all(
+        hist.values() == [0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0]
+    )

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -574,7 +574,6 @@ def test_155_boost_factory():
 
     dak = pytest.importorskip("dask_awkward")
 
-
     import dask_histogram as dh
 
     arr = dak.from_lists([list(range(10))] * 3)
@@ -588,6 +587,7 @@ def test_155_boost_factory():
 
 def test_155_2():
     import boost_histogram as bh
+
     import dask_histogram as dh
 
     dak = pytest.importorskip("dask_awkward")

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -573,7 +573,7 @@ def test_155_boost_factory():
     import boost_histogram as bh
 
     dak = pytest.importorskip("dask_awkward")
-    import numpy as np
+
 
     import dask_histogram as dh
 
@@ -588,9 +588,9 @@ def test_155_boost_factory():
 
 def test_155_2():
     import boost_histogram as bh
-    import dask_awkward as dak
-
     import dask_histogram as dh
+
+    dak = pytest.importorskip("dask_awkward")
 
     arr = dak.from_lists([list(range(10))] * 3)
     axis = bh.axis.Regular(10, 0.0, 10.0)

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -589,6 +589,7 @@ def test_155_boost_factory():
 def test_155_2():
     import boost_histogram as bh
     import dask_awkward as dak
+
     import dask_histogram as dh
 
     arr = dak.from_lists([list(range(10))] * 3)

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -602,3 +602,37 @@ def test_155_2():
     assert np.all(
         hist.values() == [0.0, 3.0, 6.0, 9.0, 12.0, 15.0, 18.0, 21.0, 24.0, 27.0]
     )
+
+
+def test_155_3_2d():
+    import boost_histogram as bh
+
+    dak = pytest.importorskip("dask_awkward")
+
+    import dask_histogram as dh
+
+    arr1 = dak.from_lists([list(range(10))] * 3)
+    arr2 = dak.from_lists([list(reversed(range(10)))] * 3)
+    axis1 = bh.axis.Regular(10, 0.0, 10.0)
+    axis2 = bh.axis.Regular(10, 0.0, 10.0)
+    hist = dh.factory(
+        arr1,
+        arr2,
+        axes=(axis1, axis2),
+        weights=arr1,
+    ).compute()
+    should_be = (
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 6.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 9.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 12.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 15.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 18.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 21.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 24.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [27.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ],
+    )
+    assert np.all(hist.values() == should_be)


### PR DESCRIPTION
Second try at fixing #155 

Only lift the histref into the partial and avoid hiding `sample` and `weights` in the function object when then they are _also_ dask collections.