### PR TITLE
chore: pyproject.toml & CI updates

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{matrix.platform}}
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{matrix.platform}}
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{matrix.platform}}
     steps:
     - name: Checkout

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,6 @@
 repos:
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-  - id: black
-    language_version: python3
-    args:
-    - --target-version=py38
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.3
+  rev: v0.8.4
   hooks:
   - id: ruff
-- repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
-  hooks:
-  - id: isort
-    language_version: python3
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.19.0
-  hooks:
-  - id: pyupgrade
-    args:
-    - --py38-plus
-- repo: https://github.com/MarcoGorelli/absolufy-imports
-  rev: v0.3.1
-  hooks:
-  - id: absolufy-imports
+  - id: ruff-format

--- a/docs/dh_demo.ipynb
+++ b/docs/dh_demo.ipynb
@@ -8,9 +8,10 @@
    "outputs": [],
    "source": [
     "# dask_histogram --> boost-histogram fillable with dask collections.\n",
-    "import dask_histogram as dh\n",
+    "import boost_histogram as bh\n",
     "import dask.array as da\n",
-    "import boost_histogram as bh"
+    "\n",
+    "import dask_histogram as dh"
    ]
   },
   {

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -38,35 +38,6 @@ Push the tag to GitHub (assuming ``origin`` points to the
 Making the release
 ------------------
 
-To make a release of ``dask-histogram`` we just need the ``build`` and
-``twine`` packages:
-
-.. code-block::
-
-   $ pip install build twine
-
-The build-system that we use (``hatch`` with ``hatch-vcs``) will
-automatically set a version based on the latest tag in the repository;
-after making the tag we just need to generate the source distribution
-and wheel, this is handled by the ``build`` package:
-
-.. code-block::
-
-   $ python -m build
-
-Now a new ``dist/`` directory will appear, which contains the files
-(continuing to use our example version ``2023.3.1``):
-
-.. code-block::
-
-   dask_histogram-2023.3.1.tar.gz
-   dask_histogram-2023.3.1-py3-none-any.whl
-
-Now we just upload these files to PyPI with ``twine``:
-
-.. code-block::
-
-   $ twine upload dist/dask_histogram-2023.3.1*
-
-The GitHub ``regro-cf-autotick-bot`` account will automatically create
-a pull request to release a new version on ``conda-forge``.
+After pushing the tag, GitHub actions will take care of uploading the
+wheel and sdist to PyPI. Please go to the Releases page on the GitHub
+repository and Draft a new release associated with the tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,11 +83,6 @@ include = ["/src"]
 addopts = "-v"
 testpaths = ["tests"]
 
-[tool.isort]
-profile = "black"
-line_length = 88
-src_paths = ["src", "tests"]
-
 [tool.mypy]
 python_version = "3.9"
 files = ["src", "tests"]
@@ -107,6 +102,10 @@ ignore_missing_imports = true
 
 [tool.pydocstyle]
 ignore = "D105"
+
+[tool.ruff]
+line-length = 88
+src = ["src", "tests"]
 
 [tool.ruff.lint]
 ignore = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dask-histogram"
 description = "Histogramming with Dask."
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Doug Davis", email = "ddavis@ddavis.io" },
 ]
@@ -16,11 +16,11 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Mathematics",
@@ -34,17 +34,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 complete = [
-    "dask-sphinx-theme >=3.0.2",
-    "dask[array,dataframe]",
-    "dask-awkward >=2023.10.0",
-    "hist",
-    "pytest",
-    "sphinx >=4.0.0",
-    "sphinxcontrib-applehelp>=1.0.0,<1.0.7",
-    "sphinxcontrib-devhelp>=1.0.0,<1.0.6",
-    "sphinxcontrib-htmlhelp>=2.0.0,<2.0.5",
-    "sphinxcontrib-serializinghtml>=1.1.0,<1.1.10",
-    "sphinxcontrib-qthelp>=1.0.0,<1.0.7",
+    "dask-histogram[docs,test]"
 ]
 docs = [
     "dask-sphinx-theme >=3.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,6 @@ ignore_missing_imports = true
 [tool.pydocstyle]
 ignore = "D105"
 
-[tool.ruff]
+[tool.ruff.lint]
 ignore = ["E501"]
 per-file-ignores = {"__init__.py" = ["E402", "F401"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dask-histogram"
 description = "Histogramming with Dask."
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 authors = [
     { name = "Doug Davis", email = "ddavis@ddavis.io" },
 ]
@@ -16,6 +16,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -104,6 +105,7 @@ ignore_missing_imports = true
 ignore = "D105"
 
 [tool.ruff]
+target-version = "py38"
 line-length = 88
 src = ["src", "tests"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,5 +108,6 @@ line-length = 88
 src = ["src", "tests"]
 
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = ["E501"]
 per-file-ignores = {"__init__.py" = ["E402", "F401"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dask-histogram"
 description = "Histogramming with Dask."
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Doug Davis", email = "ddavis@ddavis.io" },
 ]
@@ -16,7 +16,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
- Test 3.13
- Simplify `pyproject.toml` optional deps.
- Drop some docs (manual release upload) that aren't necessary anymore
- drop some entries in pre-commit, use ruff for those task
- drop 3.8