### PR TITLE
Import Tree from dask-awkward if not in dask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         python3 -m pip install pip wheel
         python3 -m pip install -q --no-cache-dir -e .[complete]
+        python3 -m pip install git+https://github.com/dask-contrib/dask-awkward
         python3 -m pip list
     - name: test
       env: {"DASK_DATAFRAME__QUERY_PLANNING": "False"}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.1
+  rev: v0.9.3
   hooks:
   - id: ruff
+    args: [--fix, --show-fixes]
   - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "boost-histogram>=1.3.2",
     "dask>=2021.03.0",
+    "dask-awkward >=2025",
 ]
 dynamic = ["version"]
 
@@ -39,7 +40,6 @@ complete = [
 docs = [
     "dask-sphinx-theme >=3.0.2",
     "dask[array,dataframe]",
-    "dask-awkward >=2023.10.0",
     # FIXME: `sphinxcontrib-*` pins are a workaround until we have sphinx>=5.
     #        See https://github.com/dask/dask-sphinx-theme/issues/68.
     "sphinx >=4.0.0",
@@ -51,7 +51,6 @@ docs = [
 ]
 test = [
     "dask[array,dataframe]",
-    "dask-awkward >=2023.10.0",
     "hist",
     "pytest",
 ]

--- a/src/dask_histogram/core.py
+++ b/src/dask_histogram/core.py
@@ -920,14 +920,14 @@ def _weight_sample_check(
 
 def _is_dask_dataframe(obj):
     return (
-        obj.__class__.__module__ == "dask.dataframe.core"
+        type(obj).__module__.startswith("dask.dataframe")
         and obj.__class__.__name__ == "DataFrame"
     )
 
 
 def _is_dask_series(obj):
     return (
-        obj.__class__.__module__ == "dask.dataframe.core"
+        type(obj).__module__.startswith("dask.dataframe")
         and obj.__class__.__name__ == "Series"
     )
 

--- a/src/dask_histogram/layers.py
+++ b/src/dask_histogram/layers.py
@@ -1,4 +1,14 @@
-from dask.layers import DataFrameTreeReduction
+try:
+    from dask.layers import DataFrameTreeReduction
+except ImportError:
+    try:
+        from dask_awkward.layers import AwkwardTreeReductionLayer as DataFrameTreeReduction
+    except ImportError:
+        DataFrameTreeReduction = None
+
+if DataFrameTreeReduction is None:
+    raise ImportError("DataFrameReduction is unimportable - either downgrade dask to <2025"
+                      "or install dask-awkward >=2025.")
 
 
 class MockableDataFrameTreeReduction(DataFrameTreeReduction):

--- a/src/dask_histogram/typing.py
+++ b/src/dask_histogram/typing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional, Sequence, Tuple, Union
 
 from dask.array.core import Array
-from dask.dataframe.core import DataFrame, Series
+from dask.dataframe import DataFrame, Series
 from numpy.typing import ArrayLike
 
 BinType = Union[int, ArrayLike]

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -2,6 +2,7 @@ import boost_histogram as bh
 import boost_histogram.numpy as bhnp
 import dask.array as da
 import numpy as np
+from packaging.version import parse as parse_version
 import pytest
 
 import dask_histogram.boost as dhb
@@ -247,6 +248,10 @@ def test_histogramdd_multicolumn_input():
     np.testing.assert_array_almost_equal(h1.view(), h2.view())
 
 
+@pytest.mark.xfail(
+    parse_version(dask.__version__) >= parse_version("2025"),
+    reason="to_dataframe is broken with dask 2025.1.0",
+)
 def test_histogramdd_series():
     pytest.importorskip("pandas")
 
@@ -276,6 +281,10 @@ def test_histogramdd_series():
     np.testing.assert_array_almost_equal(h1.view()["variance"], h2.view()["variance"])
 
 
+@pytest.mark.xfail(
+    parse_version(dask.__version__) >= parse_version("2025"),
+    reason="to_dataframe is broken with dask 2025.1.0",
+)
 def test_histogramdd_arrays_and_series():
     pytest.importorskip("pandas")
 
@@ -305,6 +314,10 @@ def test_histogramdd_arrays_and_series():
     np.testing.assert_array_almost_equal(h1.view()["variance"], h2.view()["variance"])
 
 
+@pytest.mark.xfail(
+    parse_version(dask.__version__) >= parse_version("2025"),
+    reason="to_dataframe is broken with dask 2025.1.0",
+)
 def test_histogramdd_dataframe():
     pytest.importorskip("pandas")
     x = da.random.standard_normal(size=(1000, 3), chunks=(200, 3))

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -3,8 +3,8 @@ import boost_histogram.numpy as bhnp
 import dask
 import dask.array as da
 import numpy as np
-from packaging.version import parse as parse_version
 import pytest
+from packaging.version import parse as parse_version
 
 import dask_histogram.boost as dhb
 import dask_histogram.core as dhc

--- a/tests/test_boost.py
+++ b/tests/test_boost.py
@@ -1,5 +1,6 @@
 import boost_histogram as bh
 import boost_histogram.numpy as bhnp
+import dask
 import dask.array as da
 import numpy as np
 from packaging.version import parse as parse_version

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6,6 +6,7 @@ import dask.array.utils as dau
 import numpy as np
 import pytest
 from dask.delayed import delayed
+from packaging.version import parse as parse_version
 
 import dask_histogram.core as dhc
 
@@ -124,6 +125,10 @@ def test_nd_array(weights):
     np.testing.assert_allclose(h.counts(flow=True), dh.compute().counts(flow=True))
 
 
+@pytest.mark.xfail(
+    parse_version(dask.__version__) >= parse_version("2025"),
+    reason="dask dataframe changed substantially in 2025.1.0",
+)
 @pytest.mark.parametrize("weights", [True, None])
 def test_df_input(weights):
     pytest.importorskip("pandas")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import boost_histogram as bh
+import dask
 import dask.array as da
 import dask.array.utils as dau
 import numpy as np


### PR DESCRIPTION
Following the disappearance of DataframeTreeReduction in upstream dask, it was copied to dask-awkward, making it a required dependency in the future.

cc @lgray 